### PR TITLE
Prevent error caused by conflicting manifests.

### DIFF
--- a/build/cmake/CMakeLists/core/CMakeLists.txt
+++ b/build/cmake/CMakeLists/core/CMakeLists.txt
@@ -34,6 +34,12 @@ set(LIB_HEADERS
 	${WXFILES_ALL_GUI_HEADERS}
 )
 
+foreach (hdr ${LIB_HEADERS})
+	# There are .cpp files in the headers. To exclude all of them from compilation,
+	# we use this command unconditionally (it does no harm on .h files)
+	set_source_files_properties(${hdr} PROPERTIES HEADER_FILE_ONLY TRUE)
+endforeach ()
+
 wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURCE_DIR}/include/wx/wxprec.h")
 
 wx_set_source_groups()


### PR DESCRIPTION
The MSW headers in the core project aren't marked as headers explicitly.  This means that non-.h files, such as the manifest files, are compiled into the project.  However, the manifest files cannot be compiled into the same project because they are for different architectures.  Therefore the build breaks.

This fixes the issue by marking them explicitly, in the same way as done in the base project.

Fixes #5.