### PR TITLE
Make static or shared libraries a configurable option.

### DIFF
--- a/build/cmake/CMakeLists/adv/CMakeLists.txt
+++ b/build/cmake/CMakeLists/adv/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME adv)
 
-add_definitions(-DWXMAKINGDLL_ADV -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_ADV -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -19,7 +23,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h

--- a/build/cmake/CMakeLists/aui/CMakeLists.txt
+++ b/build/cmake/CMakeLists/aui/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME aui)
 
-add_definitions(-DWXMAKINGDLL_AUI -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_AUI -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -16,7 +20,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -27,4 +31,3 @@ set(_deps)
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core ${_deps})
-

--- a/build/cmake/CMakeLists/base/CMakeLists.txt
+++ b/build/cmake/CMakeLists/base/CMakeLists.txt
@@ -9,10 +9,14 @@ endif ()
 
 include_directories(${WX_SOURCE_DIR}/src/regex)
 
-add_definitions(-DWXMAKINGDLL_BASE -DwxUSE_BASE=1 -DwxUSE_GUI=0)
+add_definitions(-DwxUSE_BASE=1 -DwxUSE_GUI=0)
 
-set(LIB_SRC 
-	${WXFILES_BASE_SRC} 
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_BASE)
+endif()
+
+set(LIB_SRC
+	${WXFILES_BASE_SRC}
 	${WXFILES_BASE_AND_GUI_SRC}
 	${WXFILES_BASE_PLATFORM_SRC}
 	${WXFILES_BASE_AND_GUI_PLATFORM_SRC}
@@ -33,7 +37,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h

--- a/build/cmake/CMakeLists/core/CMakeLists.txt
+++ b/build/cmake/CMakeLists/core/CMakeLists.txt
@@ -21,7 +21,11 @@ endif ()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
-add_definitions(-DWXMAKINGDLL_CORE -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_CORE -DWXUSINGDLL)
+endif()
 
 set(LIB_SRC
 	${WXFILES_BASE_AND_GUI_SRC}
@@ -38,7 +42,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h

--- a/build/cmake/CMakeLists/gl/CMakeLists.txt
+++ b/build/cmake/CMakeLists/gl/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME gl)
 
-add_definitions(-DWXMAKINGDLL_GL -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_GL -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -16,7 +20,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -33,4 +37,3 @@ endif ()
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core ${_deps})
-

--- a/build/cmake/CMakeLists/html/CMakeLists.txt
+++ b/build/cmake/CMakeLists/html/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME html)
 
-add_definitions(-DWXMAKINGDLL_HTML -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_HTML -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -16,7 +20,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -27,4 +31,3 @@ set(_deps)
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core ${_deps})
-

--- a/build/cmake/CMakeLists/media/CMakeLists.txt
+++ b/build/cmake/CMakeLists/media/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME media)
 
-add_definitions(-DWXMAKINGDLL_MEDIA -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_MEDIA -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -16,7 +20,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -27,4 +31,3 @@ set(_deps)
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core ${_deps})
-

--- a/build/cmake/CMakeLists/net/CMakeLists.txt
+++ b/build/cmake/CMakeLists/net/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME net)
 
-add_definitions(-DWXMAKINGDLL_NET -DwxUSE_BASE=1 -DwxUSE_GUI=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=1 -DwxUSE_GUI=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_NET -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -18,7 +22,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -33,4 +37,3 @@ endif ()
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core ${_deps})
-

--- a/build/cmake/CMakeLists/propgrid/CMakeLists.txt
+++ b/build/cmake/CMakeLists/propgrid/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME propgrid)
 
-add_definitions(-DWXMAKINGDLL_PROPGRID -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_PROPGRID -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -16,7 +20,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -27,4 +31,3 @@ set(_deps)
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core adv ${_deps})
-

--- a/build/cmake/CMakeLists/qa/CMakeLists.txt
+++ b/build/cmake/CMakeLists/qa/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME qa)
 
-add_definitions(-DWXMAKINGDLL_QA -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_QA -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -16,7 +20,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -27,4 +31,3 @@ set(_deps)
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core xml ${_deps})
-

--- a/build/cmake/CMakeLists/ribbon/CMakeLists.txt
+++ b/build/cmake/CMakeLists/ribbon/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME ribbon)
 
-add_definitions(-DWXMAKINGDLL_RIBBON -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_RIBBON -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -16,7 +20,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -27,4 +31,3 @@ set(_deps)
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core ${_deps})
-

--- a/build/cmake/CMakeLists/richtext/CMakeLists.txt
+++ b/build/cmake/CMakeLists/richtext/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME richtext)
 
-add_definitions(-DWXMAKINGDLL_RICHTEXT -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_RICHTEXT -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -16,7 +20,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -27,4 +31,3 @@ set(_deps)
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core html xml propgrid ${_deps})
-

--- a/build/cmake/CMakeLists/stc/CMakeLists.txt
+++ b/build/cmake/CMakeLists/stc/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME stc)
 
-add_definitions(-DWXMAKINGDLL_STC -DwxUSE_BASE=0 -DWXUSINGDLL -D__WX__ -DSCI_LEXER -DLINK_LEXERS)
+add_definitions(-DwxUSE_BASE=0 -D__WX__ -DSCI_LEXER -DLINK_LEXERS)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_STC -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 include_directories(${WX_SOURCE_DIR}/src/stc/scintilla/include ${WX_SOURCE_DIR}/src/stc/scintilla/src ${WX_SOURCE_DIR}/src/stc/scintilla/lexlib)
@@ -17,7 +21,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -28,4 +32,3 @@ set(_deps)
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core wxscintilla ${_deps})
-

--- a/build/cmake/CMakeLists/webview/CMakeLists.txt
+++ b/build/cmake/CMakeLists/webview/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME webview)
 
-add_definitions(-DWXMAKINGDLL_WEBVIEW -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_WEBVIEW -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS} ${WEBKIT_INCLUDE_DIRS})
 
@@ -16,7 +20,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -27,4 +31,3 @@ set(_deps)
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES} ${WEBKIT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core ${_deps})
-

--- a/build/cmake/CMakeLists/wxscintilla/CMakeLists.txt
+++ b/build/cmake/CMakeLists/wxscintilla/CMakeLists.txt
@@ -32,7 +32,6 @@ set(LIB_SRC_LEXERS
 	${LIB_SRC_DIR}/lexers/LexCsound.cxx
 	${LIB_SRC_DIR}/lexers/LexCSS.cxx
 	${LIB_SRC_DIR}/lexers/LexD.cxx
-	${LIB_SRC_DIR}/lexers/LexDMAP.cxx
 	${LIB_SRC_DIR}/lexers/LexECL.cxx
 	${LIB_SRC_DIR}/lexers/LexEiffel.cxx
 	${LIB_SRC_DIR}/lexers/LexErlang.cxx
@@ -46,8 +45,6 @@ set(LIB_SRC_LEXERS
 	${LIB_SRC_DIR}/lexers/LexHTML.cxx
 	${LIB_SRC_DIR}/lexers/LexInno.cxx
 	${LIB_SRC_DIR}/lexers/LexKix.cxx
-	${LIB_SRC_DIR}/lexers/LexKVIrc.cxx
-	${LIB_SRC_DIR}/lexers/LexLaTeX.cxx
 	${LIB_SRC_DIR}/lexers/LexLisp.cxx
 	${LIB_SRC_DIR}/lexers/LexLout.cxx
 	${LIB_SRC_DIR}/lexers/LexLua.cxx
@@ -69,7 +66,6 @@ set(LIB_SRC_LEXERS
 	${LIB_SRC_DIR}/lexers/LexPB.cxx
 	${LIB_SRC_DIR}/lexers/LexPerl.cxx
 	${LIB_SRC_DIR}/lexers/LexPLM.cxx
-	${LIB_SRC_DIR}/lexers/LexPO.cxx
 	${LIB_SRC_DIR}/lexers/LexPOV.cxx
 	${LIB_SRC_DIR}/lexers/LexPowerPro.cxx
 	${LIB_SRC_DIR}/lexers/LexPowerShell.cxx
@@ -79,7 +75,6 @@ set(LIB_SRC_LEXERS
 	${LIB_SRC_DIR}/lexers/LexR.cxx
 	${LIB_SRC_DIR}/lexers/LexRebol.cxx
 	${LIB_SRC_DIR}/lexers/LexRuby.cxx
-	${LIB_SRC_DIR}/lexers/LexRust.cxx
 	${LIB_SRC_DIR}/lexers/LexScriptol.cxx
 	${LIB_SRC_DIR}/lexers/LexSmalltalk.cxx
 	${LIB_SRC_DIR}/lexers/LexSML.cxx
@@ -87,7 +82,6 @@ set(LIB_SRC_LEXERS
 	${LIB_SRC_DIR}/lexers/LexSpecman.cxx
 	${LIB_SRC_DIR}/lexers/LexSpice.cxx
 	${LIB_SRC_DIR}/lexers/LexSQL.cxx
-	${LIB_SRC_DIR}/lexers/LexSTTXT.cxx
 	${LIB_SRC_DIR}/lexers/LexTACL.cxx
 	${LIB_SRC_DIR}/lexers/LexTADS3.cxx
 	${LIB_SRC_DIR}/lexers/LexTAL.cxx
@@ -104,7 +98,6 @@ set(LIB_SRC_LEXERS
 
 set(LIB_SRC_LEXLIB
 	${LIB_SRC_DIR}/lexlib/Accessor.cxx
-	${LIB_SRC_DIR}/lexlib/CharacterCategory.cxx
 	${LIB_SRC_DIR}/lexlib/CharacterSet.cxx
 	${LIB_SRC_DIR}/lexlib/LexerBase.cxx
 	${LIB_SRC_DIR}/lexlib/LexerModule.cxx
@@ -118,8 +111,6 @@ set(LIB_SRC_LEXLIB
 set(LIB_SRC_BASE
 	${LIB_SRC_DIR}/src/AutoComplete.cxx
 	${LIB_SRC_DIR}/src/CallTip.cxx
-	${LIB_SRC_DIR}/src/CaseConvert.cxx
-	${LIB_SRC_DIR}/src/CaseFolder.cxx
 	${LIB_SRC_DIR}/src/Catalogue.cxx
 	${LIB_SRC_DIR}/src/CellBuffer.cxx
 	${LIB_SRC_DIR}/src/CharClassify.cxx

--- a/build/cmake/CMakeLists/xml/CMakeLists.txt
+++ b/build/cmake/CMakeLists/xml/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME xml)
 
-add_definitions(-DWXMAKINGDLL_XML -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_XML -DWXUSINGDLL)
+endif()
 
 if (NOT WXBUILD_SYSTEM_EXPAT)
     include_directories(${WXBUILD_PORT_INCLUDE_DIRS} ${WX_SOURCE_DIR}/src/expat/lib)
@@ -20,7 +24,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -35,4 +39,3 @@ else ()
 endif ()
 
 target_link_libraries(${LIB_NAME} core ${_deps})
-

--- a/build/cmake/CMakeLists/xrc/CMakeLists.txt
+++ b/build/cmake/CMakeLists/xrc/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LIB_NAME xrc)
 
-add_definitions(-DWXMAKINGDLL_XRC -DwxUSE_BASE=0 -DWXUSINGDLL)
+add_definitions(-DwxUSE_BASE=0)
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWXMAKINGDLL_XRC -DWXUSINGDLL)
+endif()
 
 include_directories(${WXBUILD_PORT_INCLUDE_DIRS})
 
@@ -16,7 +20,7 @@ wx_set_pch(LIB_SRC ${WX_SOURCE_DIR}/src/common/dummy.cpp wx/wxprec.h "${WX_SOURC
 
 wx_set_source_groups()
 
-add_library(${LIB_NAME} SHARED
+add_library(${LIB_NAME}
 	${LIB_SRC}
 	${LIB_HEADERS}
 	${PROJECT_BINARY_DIR}/include/wx/setup.h
@@ -27,4 +31,3 @@ set(_deps)
 list(APPEND _deps ${WXBUILD_PORT_LIBRARIES})
 
 target_link_libraries(${LIB_NAME} core xml html adv ${_deps})
-

--- a/build/cmake/wxwidgets.cmake
+++ b/build/cmake/wxwidgets.cmake
@@ -44,6 +44,9 @@ wx_regen_setup_h()
 include("${WX_CMAKE_DIR}/files.cmake")
 
 # Prepare general options
+## BUILD_SHARED_LIBS doesn't need a WX prefix because it
+## is built into CMake and we are just exposing it
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(WXBUILD_SAMPLES "Build the samples" OFF)
 
 # Instruct CMake to handle the FOLDER property on targets


### PR DESCRIPTION
Previously the build was overriding the inbuilt facility in CMake for switching between producing static and shared libraries.  This change lets CMake decide which to produce, based on the value of the inbuilt `BUILD_SHARED_LIBS` variable.  We also expose this variable as an explicit option.